### PR TITLE
Update sharedInstance type

### DIFF
--- a/Prephirences/Prephirences.swift
+++ b/Prephirences/Prephirences.swift
@@ -31,7 +31,7 @@ import Foundation
 public class Prephirences {
 
     /** Shared preferences. Could be replaced by any other preferences */
-    public static var sharedInstance: PreferencesType = MutableDictionaryPreferences()
+    public static var sharedInstance: MutablePreferencesType = MutableDictionaryPreferences()
 
     // MARK: register by key
     private static var _instances: Dictionary<PrephirencesKey,PreferencesType> = Dictionary<PrephirencesKey,PreferencesType>()


### PR DESCRIPTION
sharedInstance is type MutableDictionaryPreferences, however the definition does not specify it's mutability. 

This particularly causes an issue when using Alamofire-Prephirences because the associated extensions only work with MutablePreferencesType.
