### PR TITLE
Example project swift 3 update; fix a crash

### DIFF
--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -130,6 +130,7 @@
 					C4F94CFB1D48A70D0045D4B6 = {
 						CreatedOnToolsVersion = 7.3.1;
 						DevelopmentTeam = GGU39CDBL2;
+						LastSwiftMigration = 0820;
 					};
 				};
 			};
@@ -340,6 +341,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = fr.phimage.Example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -352,6 +354,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = fr.phimage.Example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/Example/Example/AppDelegate.swift
+++ b/Example/Example/AppDelegate.swift
@@ -14,7 +14,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
-    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
 
         // Check preference from StaticConfig
@@ -27,25 +27,25 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return true
     }
 
-    func applicationWillResignActive(application: UIApplication) {
+    func applicationWillResignActive(_ application: UIApplication) {
         // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
         // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
     }
 
-    func applicationDidEnterBackground(application: UIApplication) {
+    func applicationDidEnterBackground(_ application: UIApplication) {
         // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
         // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
     }
 
-    func applicationWillEnterForeground(application: UIApplication) {
+    func applicationWillEnterForeground(_ application: UIApplication) {
         // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
     }
 
-    func applicationDidBecomeActive(application: UIApplication) {
+    func applicationDidBecomeActive(_ application: UIApplication) {
         // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
     }
 
-    func applicationWillTerminate(application: UIApplication) {
+    func applicationWillTerminate(_ application: UIApplication) {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
 

--- a/Example/Example/Base.lproj/Main.storyboard
+++ b/Example/Example/Base.lproj/Main.storyboard
@@ -211,6 +211,7 @@
                         <outlet property="boolLabel" destination="j1u-U7-Ve2" id="gBR-eJ-7w3"/>
                         <outlet property="numberFromDefaultSlider" destination="2hb-fW-aTH" id="uy7-Ta-lCZ"/>
                         <outlet property="numberLabel" destination="47f-6u-VLq" id="GPb-ju-eWO"/>
+                        <outlet property="stringFromDefaultLabel" destination="aey-wI-qAS" id="dwp-rP-MNv"/>
                         <outlet property="stringLabel" destination="Ija-hm-4sc" id="huG-K4-zTC"/>
                         <outlet property="versionLabel" destination="kCM-vy-Sdf" id="Zar-mQ-Dao"/>
                     </connections>

--- a/Example/Example/MyPref.swift
+++ b/Example/Example/MyPref.swift
@@ -22,12 +22,12 @@ enum PlistKey: String {
 /// A subscript to use with PlistKey
 extension PreferencesType {
     subscript(key: PlistKey) -> AnyObject? {
-        return self[key.rawValue]
+        return self[key.rawValue] as AnyObject
     }
 }
 
 // MARK: NSUserDefaults
-let UserDefaults = NSUserDefaults.standardUserDefaults()
+let UserDefaults = Foundation.UserDefaults.standard
 
 class FromDefaults { // or extension NSUserDefaults or other model class ...
     /// example of variable binded on UserDefaults
@@ -46,5 +46,5 @@ class FromDefaults { // or extension NSUserDefaults or other model class ...
 let StaticKey = "key"
 let StaticValue = "value"
 let StaticConfig: DictionaryPreferences = [StaticKey: StaticValue]
-let MainBundle = NSBundle.mainBundle()
+let MainBundle = Bundle.main
 let Preferences: MutableCompositePreferences = [StaticConfig, AppConfig, UserDefaults, MainBundle]

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -40,9 +40,9 @@ class ViewController: UITableViewController {
         // From UserDefaults
         stringFromDefaultLabel.text = FromDefaults.string ?? "Enter a string"
         numberFromDefaultSlider.value = UserDefaults["DefaultKeyNumber"] as? Float ?? 0
-        boolFromDefaultsSwitch.on = UserDefaults["DefaultKeyBool"] as? Bool ?? true
+        boolFromDefaultsSwitch.isOn = UserDefaults["DefaultKeyBool"] as? Bool ?? true
 
-        stringFromDefaultLabel.addTarget(self, action: #selector(ViewController.textFieldDidChange(_:)), forControlEvents: UIControlEvents.EditingChanged)
+        stringFromDefaultLabel.addTarget(self, action: #selector(ViewController.textFieldDidChange(_:)), for: UIControlEvents.editingChanged)
     }
 
     override func didReceiveMemoryWarning() {
@@ -53,16 +53,16 @@ class ViewController: UITableViewController {
     // Set values to defaults
     // could also use bind api...
 
-    @IBAction func textFieldDidChange(sender: UITextField) {
+    @IBAction func textFieldDidChange(_ sender: UITextField) {
         FromDefaults.string = sender.text
         UserDefaults.synchronize()
     }
-    @IBAction func sliderChanged(sender: UISlider) {
+    @IBAction func sliderChanged(_ sender: UISlider) {
         UserDefaults["DefaultKeyNumber"] = sender.value
         UserDefaults.synchronize()
     }
-    @IBAction func switchChanged(sender: UISwitch) {
-        UserDefaults["DefaultKeyBool"] = sender.on
+    @IBAction func switchChanged(_ sender: UISwitch) {
+        UserDefaults["DefaultKeyBool"] = sender.isOn
         UserDefaults.synchronize()
     }
 }


### PR DESCRIPTION
Update example project to Swift 3
Fix a crash by connecting `stringFromDefaultLabel` in `ViewController` to its corresponding text field in storyboard