### PR TITLE
Updated Keychain accessible Docs to latest API

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ if let pass = keychain.stringForKey("anUserName") {..}
 ```
 **Accessibility**
 ````
-keychain.accessibility = .AccessibleAfterFirstUnlock
+keychain.accessible = .afterFirstUnlock
 ````
 
 **Sharing Keychain items**


### PR DESCRIPTION
Hi, thanks for all your work.

While reading through your README and playing around with Prephirences, I noticed the `.accessibility`-property has been renamed to `.accessible`. And all enum cases of `SecurityAttributeAccessible` were renamed, too.